### PR TITLE
Fixed getFreqMode, setMode

### DIFF
--- a/lib/ft817/ft817.cpp
+++ b/lib/ft817/ft817.cpp
@@ -266,7 +266,8 @@ bool FT817::getVFO()
 {
 	MSB = 0x00;	// set the address to read
 	LSB = 0x55;
-	return (bool((readEEPROM() & 0b00000001)));    // debug in progress here... g7uhn
+	readEEPROM();
+	return (bool)(actualByte & 0b00000001);    // 0 = VFO A, 1 = VFO B
 }
 
 // get the mode indirectly
@@ -448,14 +449,14 @@ void FT817::flushBuffer()
 // it loads two bytes, they are placed in actualByte & nextByte
 bool FT817::readEEPROM()
 {
-	// there is evidence that this fails?
+	// set 'valid data' flag to false, we see two consequtive matching reads we set it to true
 	eepromValidData = false;
 	for (byte i=0; i<4; i++)
 	{
 		flushBuffer();
 		buffer[0] = MSB;  // MSB EEPROM data byte
 		buffer[1] = LSB;  // LSB EEPROM data byte
-		buffer[4] = 0xBB; // BB command byte (read EEPROM data)sendCmd();
+		buffer[4] = 0xBB; // BB command byte (read EEPROM data) for sendCmd();
 		sendCmd();
 		getBytes(2);
 		if ((i > 0) & ((actualByte == buffer[0]) & (nextByte == buffer[1])))

--- a/lib/ft817/ft817.cpp
+++ b/lib/ft817/ft817.cpp
@@ -300,7 +300,8 @@ byte FT817::getBandVFO(bool vfo)
 	// see the band specs in the .h file
 	MSB = 0x00;	// set the address to read
 	LSB = 0x59;
-	byte band = readEEPROM();
+	readEEPROM();
+	byte band = actualByte;
 	if (vfo)
 	{
 		// B
@@ -336,11 +337,13 @@ boolean FT817::chkTX()
 
 // get display selection
 // values from 0x00 to 0x0B
+// only valid if eepromDataValid is true
 byte FT817::getDisplaySelection()
 {
 	MSB = 0x00;	// set the address to read
 	LSB = 0x76;
-	return readEEPROM();
+	readEEPROM();
+	return actualByte & 0b00001111;    // display selection is bits 0-3 of hex address 0x76
 }
 
 // get smeter value

--- a/lib/ft817/ft817.h
+++ b/lib/ft817/ft817.h
@@ -409,7 +409,7 @@ class FT817
 		// vars
 		unsigned long freq;		// frequency data as a long
 		byte mode;					// last mode read
-		unsigned char buffer[5];	// buffer used to TX and RX data to the radio
+		byte buffer[5];	// buffer used to TX and RX data to the radio
 		byte MSB;					// MSB of the eeprom address | both used to calculate the address of
 		byte LSB;					// LSB of the eeprom address | the eeprom
 		byte actualByte;			// Actual byte requested by any EEPROM read operation

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:nanoatmega328new]
+[env:nanoatmega328]
 platform = atmelavr
-board = nanoatmega328new
+board = nanoatmega328
 framework = arduino

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,26 +85,40 @@ void loop()
     // Serial.println(F("Radio toggled the VFO, please check"));
     // delay(dly);
 
-    // // VFO band one
-    // byte band = radio.getBandVFO(false);
-    // if (radio.eepromValidData)
-    // {
-    //     Serial.print(F("Radio VFO A band is "));
-    //     Serial.print(band, HEX);
-    //     Serial.println(F(", please check"));
-    // }
-    // else
-    // {
-    //     Serial.println(F("Reading the VFO A band failed, please check"));
-    // }
-    // delay(dly);
+    // VFO A band
+    byte bandA = radio.getBandVFO(false);   // for getBandVFO() input, false = VFO A, true = VFO B
+    if (radio.eepromValidData)
+    {
+        Serial.print(F("Radio VFO A band is "));
+        Serial.print(bandA, HEX);
+        Serial.println(F(", please check"));
+    }
+    else
+    {
+        Serial.println(F("Reading the VFO A band failed, please check"));
+    }
+    delay(dly);
 
-    // // Check ABC softkeys
-    // byte ds = radio.getDisplaySelection();
-    // Serial.print(F("Radio display selection is "));
-    // Serial.print(ds);
-    // Serial.println(F(" please check"));
-    // delay(dly);
+    // VFO B band
+    byte bandB = radio.getBandVFO(true);   // for getBandVFO() input, false = VFO A, true = VFO B
+    if (radio.eepromValidData)
+    {
+        Serial.print(F("Radio VFO B band is "));
+        Serial.print(bandB, HEX);
+        Serial.println(F(", please check"));
+    }
+    else
+    {
+        Serial.println(F("Reading the VFO B band failed, please check"));
+    }
+    delay(dly);
+
+    // Check ABC softkeys
+    byte ds = radio.getDisplaySelection();
+    Serial.print(F("Radio display selection is "));
+    Serial.print(ds);
+    Serial.println(F(" please check"));
+    delay(dly);
 
     // // get smeter
     // byte sm = radio.getSMeter();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,13 +64,14 @@ void loop()
     bool vfo = radio.getVFO();
     if (radio.eepromValidData)
     {
+        // 0 = VFO A, 1 = VFO B
         if (vfo)
         {
-            Serial.println(F("Radio VFO A active, please check"));
+            Serial.println(F("Radio VFO B active, please check"));
         }
         else
         {
-            Serial.println(F("Radio VFO B active, please check"));
+            Serial.println(F("Radio VFO A active, please check"));
         }
     }
     else
@@ -79,45 +80,45 @@ void loop()
     }
     delay(dly);
 
-    // VFO toggle
-    radio.toggleVFO();
-    Serial.println(F("Radio toggled the VFO, please check"));
-    delay(dly);
+    // // VFO toggle
+    // radio.toggleVFO();
+    // Serial.println(F("Radio toggled the VFO, please check"));
+    // delay(dly);
 
-    // VFO band one
-    byte band = radio.getBandVFO(false);
-    if (radio.eepromValidData)
-    {
-        Serial.print(F("Radio VFO A band is "));
-        Serial.print(band, HEX);
-        Serial.println(F(", please check"));
-    }
-    else
-    {
-        Serial.println(F("Reading the VFO A band failed, please check"));
-    }
-    delay(dly);
+    // // VFO band one
+    // byte band = radio.getBandVFO(false);
+    // if (radio.eepromValidData)
+    // {
+    //     Serial.print(F("Radio VFO A band is "));
+    //     Serial.print(band, HEX);
+    //     Serial.println(F(", please check"));
+    // }
+    // else
+    // {
+    //     Serial.println(F("Reading the VFO A band failed, please check"));
+    // }
+    // delay(dly);
 
-    // Check ABC softkeys
-    byte ds = radio.getDisplaySelection();
-    Serial.print(F("Radio display selection is "));
-    Serial.print(ds);
-    Serial.println(F(" please check"));
-    delay(dly);
+    // // Check ABC softkeys
+    // byte ds = radio.getDisplaySelection();
+    // Serial.print(F("Radio display selection is "));
+    // Serial.print(ds);
+    // Serial.println(F(" please check"));
+    // delay(dly);
 
-    // get smeter
-    byte sm = radio.getSMeter();
-    Serial.print(F("Radio S-Meter value is 0x"));
-    Serial.print(sm, HEX);
-    Serial.println(F(", please check"));
-    delay(dly);
+    // // get smeter
+    // byte sm = radio.getSMeter();
+    // Serial.print(F("Radio S-Meter value is 0x"));
+    // Serial.print(sm, HEX);
+    // Serial.println(F(", please check"));
+    // delay(dly);
 
-    // get Nar status of the actual channel
-    bool Nar = radio.getNar();
-    Serial.print(F("Radio VFO Narrow state in this channel is: "));
-    Serial.print(Nar);
-    Serial.println(F(", please check"));
-    delay(dly);
+    // // get Nar status of the actual channel
+    // bool Nar = radio.getNar();
+    // Serial.print(F("Radio VFO Narrow state in this channel is: "));
+    // Serial.print(Nar);
+    // Serial.println(F(", please check"));
+    // delay(dly);
 
 #ifdef EEPROM_WRITES
     Serial.println("Now we will test some of the functions that writes to the EEPROM,");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@
 #include "ft817.h"
 
 // uncomment this is you want to test the functions that WRITES to the EEPROM 
-#define EEPROM_WRITES
+//#define EEPROM_WRITES
 
 FT817 radio; // define "radio" so that we may pass CAT commands
 
@@ -32,124 +32,35 @@ void loop()
 {
     int dly = 5000; // delay for x milliseconds between commands
 
-    Serial.print(F("Radio mode code is "));
-    Serial.print(radio.getFreqMode());
+    Serial.println(F("Radio frequency and mode code is "));
+    Serial.println(radio.getFreqMode());
+    Serial.print(radio.getMode());
     Serial.println(F(", please check"));
     delay(dly);
 
-    radio.lock(true); // lock the radio's controls
-    Serial.println(F("Radio Locked, please check"));
-    delay(dly);
+    // radio.setMode(CAT_MODE_AM); // set mode to AM
+    // Serial.println(F("Radio Mode: AM, please check"));
+    // delay(dly);
 
-    radio.lock(false); // unlock the radio's controls
-    Serial.println(F("Radio Unlocked, please check"));
-    delay(dly);
+    // radio.setMode(CAT_MODE_USB); // set mode to USB
+    // Serial.println(F("Radio Mode USB, please check"));
+    // delay(dly);
 
-    radio.setMode(CAT_MODE_PKT); // set mode to PKT (note these mode names are NOT case sensitive!)
-    Serial.println(F("Radio mode: PKT, please check"));
-    delay(dly);
+    // radio.setMode(CAT_MODE_CW); // set mode to CW
+    // Serial.println(F("Radio Mode CW, please check"));
+    // delay(dly);
 
-    radio.setMode(CAT_MODE_AM); // set mode to AM
-    Serial.println(F("Radio Mode: AM, please check"));
-    delay(dly);
+    // radio.setFreq(10150000);
+    // radio.setMode(CAT_MODE_WBFM); // set mode to WBFM
+    // Serial.println(F("Radio Mode WBFM (Broadcast band), please check"));
+    // delay(dly);
 
-    radio.setMode(CAT_MODE_USB); // set mode to USB
-    Serial.println(F("Radio Mode USB, please check"));
-    delay(dly);
+    // radio.setFreq(1407000); // set VFO frequency to xx
+    // radio.setMode(CAT_MODE_USB); // set mode to USB
+    // Serial.println(F("Radio set to USB in 14.070Mhz, please check"));
+    // delay(dly);
 
-    radio.setMode(CAT_MODE_LSB); // set mode to LSB
-    Serial.println(F("Radio Mode LSB, please check"));
-    delay(dly);
-
-    radio.setMode(CAT_MODE_CW); // set mode to CW
-    Serial.println(F("Radio Mode CW, please check"));
-    delay(dly);
-
-    radio.setMode(CAT_MODE_CWR); // set mode to CW-R
-    Serial.println(F("Radio Mode CW-R, please check"));
-    delay(dly);
-
-    radio.setMode(CAT_MODE_DIG); // set mode to DIG
-    Serial.println(F("Radio Mode DIG, please check"));
-    delay(dly);
-
-    radio.setMode(CAT_MODE_FM); // set mode to FM
-    Serial.println(F("Radio Mode FM, please check"));
-    delay(dly);
-
-    radio.setFreq(10150000);
-    radio.setMode(CAT_MODE_WBFM); // set mode to WBFM
-    Serial.println(F("Radio Mode WBFM (Broadcast band), please check"));
-    delay(dly);
-
-    radio.setFreq(1407000); // set VFO frequency to xx
-    radio.setMode(CAT_MODE_USB); // set mode to USB
-    Serial.println(F("Radio set to USB in 14.070Mhz, please check"));
-    delay(dly);
-
-    // perform a frequency sweep
-    Serial.println(F("Doing a sweep up in the 2m band, please check"));
-    radio.setMode(CAT_MODE_FM); // set mode to FM
-    for (long freq = 0; freq<100; freq++)
-    {
-        radio.setFreq(14500000 + freq * 500);
-        delay(50);
-    }
-    delay(dly);
-
-    radio.clar(true); // enable clarifier
-    Serial.println(F("Radio Clarifier ON, please check"));
-    delay(dly);
-
-    radio.clar(false); // disable clarifier
-    Serial.println(F("Radio Clarifier OFF, please check"));
-    delay(dly);
-
-    radio.split(true); // enable split operation
-    Serial.println(F("Radio Split ON, please check"));
-    delay(dly);
-
-    radio.split(false); // disable split operation
-    Serial.println(F("Radio Split OFF, please check"));
-    delay(dly);
-
-    radio.rptrOffset("+"); // set positive repeater offset
-    Serial.println(F("Radio Positive repeater offset, please check"));
-    delay(dly);
-
-    radio.rptrOffset("-"); // set negative repeater offset
-    Serial.println(F("Radio Negative repeater offset, please check"));
-    delay(dly);
-
-    radio.rptrOffsetFreq(600); // set an offset frequency in kHz
-    Serial.println(F("Radio repeater offset =  600 Khz, please check"));
-    delay(dly);
-
-    radio.rptrOffset("s"); // enable simplex mode
-    Serial.println(F("Radio Simplex mode, please check"));
-    delay(dly);
-
-    radio.squelch("TSQ"); // set the radio to CTCSS on RX & TX
-    Serial.println(F("Radio TSQ ON, please check"));
-    delay(dly);
-
-    radio.squelchFreq(1000, "C"); // set CTCSS tone 100.0Hz (TX + RX) - note the C = CTCSS tone
-    Serial.println(F("Radio TSQ CTSS, please check"));
-    delay(dly);
-
-    radio.squelch("DCS"); // set the radio to DCS on RX & TX
-    Serial.println(F("Radio DCS ON, please check"));
-    delay(dly);
-
-    radio.squelchFreq(371, "D"); // set DCS code 0371 (TX + RX) - note the D = DCS code
-    Serial.println(F("Radio DCS code 0371, please check"));
-    delay(dly);
-
-    radio.squelch("OFF"); // clear CTCSS & DCS squelch
-    Serial.println(F("Radio TSQ OFF, please check"));
-    delay(dly);
-
-    // VFO
+    // Check VFO in use
     bool vfo = radio.getVFO();
     if (radio.eepromValidData)
     {
@@ -187,7 +98,7 @@ void loop()
     }
     delay(dly);
 
-    // display
+    // Check ABC softkeys
     byte ds = radio.getDisplaySelection();
     Serial.print(F("Radio display selection is "));
     Serial.print(ds);


### PR DESCRIPTION
OK, I realise now I should have made a commit for each topic... I'll limit future pull requests to one topic.  But for now, here's my fixes so far:
- setMode - this was just a typo, it was missing the sendCmd line
- getFreqMode - a couple of issues here...
    - firstly the buffer array wasn't storing the received bytes from the radio correctly when it was unsigned char, changed to byte
    - the next issue here was that the received bytes were being loaded into the buffer array the wrong way around

Other changes:
- set the SoftwareSerial pins to (12, 11) to match my PCB
- set the environment/board to nanoatmega328 to match my Arduino Nano (not the "new" bootloader)
- reduced the setMode tests in main.cpp and moved some things around to focus on the functions I was testing